### PR TITLE
Use Cogs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dev = [
 
 [tool.coverage.run]
 include = ["src"]
-line-length = 120
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,15 @@ dev = [
   "ruff == 0.8.6",
   "pytest == 8.3.4",
   "coverage == 7.6.10", 
-  "dpytest==0.7.0",
+  "dpytest @ git+https://github.com/Javagedes/dpytest.git@master",
   "requests==2.32.2"
 ]
 
 [tool.coverage.run]
 include = ["src"]
+line-length = 120
+
+[tool.ruff]
 line-length = 120
 
 [lint]

--- a/src/cog/__init__.py
+++ b/src/cog/__init__.py
@@ -1,2 +1,4 @@
+__all__ = ["UserCog", "ServerCog"]
+
 from .user import UserCog
 from .server import ServerCog

--- a/src/cog/__init__.py
+++ b/src/cog/__init__.py
@@ -1,0 +1,2 @@
+from .user import UserCog
+from .server import ServerCog

--- a/src/cog/converter.py
+++ b/src/cog/converter.py
@@ -2,7 +2,8 @@
 
 from discord.ext import commands
 
+
 # Parses commands like `Game 1 players: 3`
-class GamePlayerCount(commands.FlagConverter, delimiter=':', case_insensitive=True):
+class GamePlayerCount(commands.FlagConverter, delimiter=":", case_insensitive=True):
     game: str = commands.flag(positional=True)
     players: int

--- a/src/cog/converter.py
+++ b/src/cog/converter.py
@@ -7,3 +7,9 @@ from discord.ext import commands
 class GamePlayerCount(commands.FlagConverter, delimiter=":", case_insensitive=True):
     game: str = commands.flag(positional=True)
     players: int
+
+# parses a list of games separated by commas
+class GameList(commands.Converter):
+    async def convert(self, _ctx: commands.Context, argument: str) -> list[str]:
+        print(argument)
+        return [game.strip() for game in argument.split(",")]

--- a/src/cog/converter.py
+++ b/src/cog/converter.py
@@ -8,8 +8,8 @@ class GamePlayerCount(commands.FlagConverter, delimiter=":", case_insensitive=Tr
     game: str = commands.flag(positional=True)
     players: int
 
+
 # parses a list of games separated by commas
 class GameList(commands.Converter):
     async def convert(self, _ctx: commands.Context, argument: str) -> list[str]:
-        print(argument)
         return [game.strip() for game in argument.split(",")]

--- a/src/cog/converter.py
+++ b/src/cog/converter.py
@@ -1,0 +1,8 @@
+# A module for any custom argument converters for commands
+
+from discord.ext import commands
+
+# Parses commands like `Game 1 players: 3`
+class GamePlayerCount(commands.FlagConverter, delimiter=':', case_insensitive=True):
+    game: str = commands.flag(positional=True)
+    players: int

--- a/src/cog/server.py
+++ b/src/cog/server.py
@@ -88,21 +88,22 @@ class ServerCog(commands.Cog):
     def suggest_game(self, guild: discord.Guild, game_data: List[Set[str]], player_count: int) -> Optional[str]:
         if not game_data:
             return None
-        
-        # Reduce the list of games to only those that are common to all users
-        games = set.intersection(*game_data)
-        
-        # Get the player counts for the games
-        with db_session:
-            player_counts = dict(select((g.name, coalesce(g.player_count, player_count)) for g in Game if g.name in games)[:])
 
-        banlist = self.get_guild_bans(guild)
-        games = []
-        for game, count in player_counts.items():
-            count_ok = count >= int(player_count)
-            banlist_ok = game not in banlist or self.bot._ignore_banlist
-            if count_ok and banlist_ok:
-                games.append(game)
+        games = set.intersection(*game_data)
+        bans = self.get_guild_bans(guild)
+    
+        # Filters the games to only those that meet the following criteria:
+        # 1. The game in the table is in the list of possible games
+        # 2. The player count is greater than or equal to the player count requested
+        # 3. The game is not in the ban list (or the bot is ignoring the ban list)
+        with db_session:
+            subquery = select(g for g in Game).filter( lambda g:
+                    g.name in games and
+                    coalesce(g.player_count, player_count) >= player_count and
+                    (g.name not in bans or self.bot._ignore_banlist)
+                )
+            
+            games = list(select(g.name for g in subquery)[:])
 
         # This is checking to see if there are any games in the list because
         # random.choice breaks if you give it an empty list.

--- a/src/cog/server.py
+++ b/src/cog/server.py
@@ -15,6 +15,9 @@ class ServerCog(commands.Cog):
     @commands.command()
     async def suggest(self, ctx: commands.Context, filter: Optional[str] = None):
         """Suggest a game to play"""
+        if not ctx.guild:
+            await ctx.send("This command is only available in servers.")
+            return
         all_games = self.get_games_guild(ctx.guild)
         if filter is None or filter == "*":
             member_count = len(ctx.guild.members)

--- a/src/cog/server.py
+++ b/src/cog/server.py
@@ -15,9 +15,7 @@ class ServerCog(commands.Cog):
     @commands.command()
     async def suggest(self, ctx: commands.Context, filter: Optional[str] = None):
         """Suggest a game to play"""
-        member_count = len(ctx.guild.members)
         all_games = self.get_games_guild(ctx.guild)
-        member_count = 0
         if filter is None or filter == "*":
             member_count = len(ctx.guild.members)
         elif filter.isdigit():
@@ -91,18 +89,18 @@ class ServerCog(commands.Cog):
 
         games = set.intersection(*game_data)
         bans = self.get_guild_bans(guild)
-    
+
         # Filters the games to only those that meet the following criteria:
         # 1. The game in the table is in the list of possible games
         # 2. The player count is greater than or equal to the player count requested
         # 3. The game is not in the ban list (or the bot is ignoring the ban list)
         with db_session:
-            subquery = select(g for g in Game).filter( lambda g:
-                    g.name in games and
-                    coalesce(g.player_count, player_count) >= player_count and
-                    (g.name not in bans or self.bot._ignore_banlist)
-                )
-            
+            subquery = select(g for g in Game).filter(
+                lambda g: g.name in games
+                and coalesce(g.player_count, player_count) >= player_count
+                and (g.name not in bans or self.bot._ignore_banlist)
+            )
+
             games = list(select(g.name for g in subquery)[:])
 
         # This is checking to see if there are any games in the list because

--- a/src/cog/server.py
+++ b/src/cog/server.py
@@ -1,0 +1,123 @@
+# A discord bot cog that manages server metadata
+from typing import List, Optional, Set
+import discord
+from discord.ext import commands
+from orm import db_session, Game, Player
+from cog.converter import GamePlayerCount
+import random
+
+class ServerCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command()
+    async def suggest(self, ctx: commands.Context, filter: Optional[str] = None):
+        """Suggest a game to play"""
+        member_count = len(ctx.guild.members)
+        all_games = self.get_games_guild(ctx.guild)
+        member_count = 0
+        if filter is None or filter == "*":
+            member_count = len(ctx.guild.members)
+        elif filter.isdigit():
+            member_count = int(filter)
+        else:
+            for channel in ctx.guild.voice_channels:
+                if filter == channel.name:
+                    member_count = len(channel.members)
+            else:
+                await ctx.send("Selected channel is not a voice channel or spelled incorrectly. Try again.")
+                return
+        game = self.suggest_game(ctx.guild, all_games, member_count)
+        if game:
+            await ctx.send(game)
+        else:
+            await ctx.send(f"No Compatible games for player count of {member_count}")
+
+    @commands.group(name="admin", invoke_without_command=True)
+    # @commands.has_permissions(administrator=True) # TODO Add permission check
+    async def admin(self, ctx: commands.Context):
+        """Admin commands for the bot"""
+        await ctx.send_help(ctx.command)
+
+    @admin.command()
+    # @commands.has_permissions(administrator=True) # TODO: Add permission check
+    async def set(self, ctx: commands.Context, *, config: GamePlayerCount):
+        """Set the player count for a game"""
+        name = config.game
+        players = config.players
+        with db_session:
+            game = Game.get(name=name) or Game(name=name) # TODO: Limit to guild managed games
+            if game is None:
+                await ctx.message.add_reaction("👎")
+                await ctx.send("Game not found.")
+                return
+
+            game.set_player_count(players)
+        await ctx.message.add_reaction("👍")
+
+    @admin.command()
+    # @commands.has_permissions(administrator=True) # TODO: Add permission check
+    async def list(self, ctx: commands.Context):
+        """List all games"""
+        with db_session:
+            games = Game.select()  # TODO Limit to guild managed games
+            games = [game.name for game in games]
+        await ctx.send(f"Games: {', '.join(games)}")
+
+    @admin.command()
+    # @commands.has_permissions(administrator=True) # TODO: Add permission check
+    async def ignore_bans(self, ctx: commands.Context, ignore: bool):
+        """Ignore user bands when selecting games."""
+        # TODO: Add this to a server settings table and keep this restriction to
+        # individual servers.
+        self.bot._ignore_banlist = ignore
+        await ctx.message.add_reaction("👍")
+
+    @db_session
+    def get_games_guild(self, guild) -> List[Set[str]]:
+        """Returns a list, where each element is a set of games that a user in the guild has."""
+        game_data = []
+        for member in guild.members:
+            if member.id not in self.bot._MEMBER_IGNORE_LIST and member.status == discord.Status.online:
+                player = Player.get(id=str(member.id)) or Player(id=str(member.id), name=member.name)
+                game_data.append(set([game.name for game in player.get_games()]))
+        return game_data
+
+    def suggest_game(self, guild: discord.Guild, game_data: List[Set[str]], player_count: int) -> Optional[str]:
+        if not game_data:
+            return None
+        potential_games = set.intersection(*game_data)
+        player_counts = self.get_game_player_counts(*potential_games, default=player_count)
+        disallowlist = self.get_guild_bans(guild)
+        games = []
+        for game in potential_games:
+            count_ok = player_counts[game] >= int(player_count)
+            disallowlist_ok = game not in disallowlist or self._ignore_disallowlist
+            if count_ok and disallowlist_ok:
+                games.append(game)
+
+        # This is checking to see if there are any games in the list because
+        # random.choice breaks if you give it an empty list.
+        # Note: this is the correct way to check for an empty list apparently.
+        if not games:
+            return None
+        else:
+            return random.choice(games)
+
+    @db_session
+    def get_game_player_counts(self, *games: str, default=0) -> dict[str, int]:
+        """Returns a dictionary of game names to player counts."""
+        data = {}
+        for game in games:
+            game = Game.get(name=game) or Game(name=game)
+            data[game.name] = game.player_count or default
+        return data
+
+    @db_session
+    def get_guild_bans(self, guild: discord.Guild) -> List[str]:
+        disallowlist = []
+        for member in guild.members:
+            if member.id not in self.bot._MEMBER_IGNORE_LIST and member.status == discord.Status.online:
+                player = Player.get(id=str(member.id)) or Player(id=str(member.id), name=member.name)
+                disallowlist += [game.name for game in player.get_banned_games()]
+        return disallowlist

--- a/src/cog/server.py
+++ b/src/cog/server.py
@@ -6,6 +6,7 @@ from orm import db_session, Game, Player
 from cog.converter import GamePlayerCount
 import random
 
+
 class ServerCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
@@ -46,7 +47,7 @@ class ServerCog(commands.Cog):
         name = config.game
         players = config.players
         with db_session:
-            game = Game.get(name=name) or Game(name=name) # TODO: Limit to guild managed games
+            game = Game.get(name=name) or Game(name=name)  # TODO: Limit to guild managed games
             if game is None:
                 await ctx.message.add_reaction("👎")
                 await ctx.send("Game not found.")
@@ -88,12 +89,12 @@ class ServerCog(commands.Cog):
             return None
         potential_games = set.intersection(*game_data)
         player_counts = self.get_game_player_counts(*potential_games, default=player_count)
-        disallowlist = self.get_guild_bans(guild)
+        banlist = self.get_guild_bans(guild)
         games = []
         for game in potential_games:
             count_ok = player_counts[game] >= int(player_count)
-            disallowlist_ok = game not in disallowlist or self._ignore_disallowlist
-            if count_ok and disallowlist_ok:
+            banlist_ok = game not in banlist or self.bot._ignore_banlist
+            if count_ok and banlist_ok:
                 games.append(game)
 
         # This is checking to see if there are any games in the list because

--- a/src/cog/user.py
+++ b/src/cog/user.py
@@ -1,0 +1,114 @@
+# A discord bot cog that manages user metadata
+from discord.ui import View, Button
+import discord
+from discord.ext import commands
+from pony.orm import db_session
+from orm import Player, Game
+import logging
+
+
+class UserCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command()
+    async def add(self, ctx: commands.Context, *games: str):
+        """Add games to user profile"""
+        games = " ".join(games)
+        games = [game.strip() for game in games.split(",")]
+
+        id = str(ctx.author.id)
+        with db_session:
+            player = Player.get(id=id) or Player(id=id, name=ctx.author.name)
+            player.add_games(*games)
+
+        logging.info(f"Added {games} to {ctx.author.name}")
+        await ctx.message.add_reaction("👍")
+
+    @commands.command()
+    async def remove(self, ctx: commands.Context, *games: str):
+        """Remove games from user profile"""
+        games = " ".join(games)
+        games = [game.strip() for game in games.split(",")]
+
+        id = str(ctx.author.id)
+        with db_session:
+            player = Player.get(id=id)
+            if player:
+                player.remove_games(*games)
+
+        logging.info(f"Removed {games} from {ctx.author.name}")
+        await ctx.message.add_reaction("👍")
+
+    @commands.command()
+    async def ban(self, ctx: commands.Context, *games: str):
+        """Ban games from user profile"""
+        games = " ".join(games)
+        games = [game.strip() for game in games.split(",")]
+
+        id = str(ctx.author.id)
+        with db_session:
+            player = Player.get(id=id)
+            if player:
+                player.add_banned_games(*games)
+
+        logging.info(f"Banned {games} from {ctx.author.name}")
+        await ctx.message.add_reaction("👍")
+
+    @commands.command()
+    async def unban(self, ctx: commands.Context, *games: str):
+        """Unban games from user profile"""
+        games = " ".join(games)
+        games = [game.strip() for game in games.split(",")]
+
+        id = str(ctx.author.id)
+        with db_session:
+            player = Player.get(id=id)
+            if player:
+                player.remove_banned_games(*games)
+
+        logging.info(f"Unbanned {games} from {ctx.author.name}")
+        await ctx.message.add_reaction("👍")
+
+    @commands.command()
+    async def list(self, ctx: commands.Context):
+        """List games in the user profile"""
+
+        async def callback(interaction: discord.Interaction):
+            with db_session:
+                player = Player.get(id=str(interaction.user.id))
+                games = [games.name for games in player.get_games()]
+                bans = [games.name for games in player.get_banned_games()]
+
+            embed = discord.Embed(
+                title="Your Games Registered with me!",
+            )
+            # List of bans (you can dynamically fetch this list)
+            games_list = "\n".join(games)
+            bans_list = "\n".join(bans)
+
+            embed.add_field(name="Your Games", value=games_list, inline=True)
+            embed.add_field(name="Your Banned Games", value=bans_list, inline=True)
+            await interaction.response.send_message(embed=embed, view=None, ephemeral=True)
+
+        games_button = Button(label="Click to View Your Games")
+        games_button.callback = callback
+
+        view = View()
+        view.add_item(games_button)
+
+        await ctx.send(view=view)
+
+    @commands.Cog.listener()
+    async def on_presence_update(self, prev, cur):
+        if prev.activities == cur.activities:
+            return
+
+        if not hasattr(cur.activity, "type"):
+            return
+
+        with db_session:
+            user = Player.get(id=str(cur.id)) or Player(id=str(cur.id), name=cur.name)
+            if cur.activity.type is discord.ActivityType.playing:
+                user.add_games(cur.activity.name)
+                logging.info(f"User starting playing {cur.activity.name}. Added to user gamelist")

--- a/src/cog/user.py
+++ b/src/cog/user.py
@@ -4,6 +4,7 @@ import discord
 from discord.ext import commands
 from pony.orm import db_session
 from orm import Player, Game, SteamMetaData
+from .converter import GameList
 import logging
 
 
@@ -45,11 +46,8 @@ class UserCog(commands.Cog):
         await ctx.send(f"{len(appids)} added to {name}'s record")
 
     @commands.command()
-    async def add(self, ctx: commands.Context, *games: str):
+    async def add(self, ctx: commands.Context, *, games: GameList):
         """Add games to user profile"""
-        games = " ".join(games)
-        games = [game.strip() for game in games.split(",")]
-
         id = str(ctx.author.id)
         with db_session:
             player = Player.get(id=id) or Player(id=id, name=ctx.author.name)
@@ -59,11 +57,8 @@ class UserCog(commands.Cog):
         await ctx.message.add_reaction("👍")
 
     @commands.command()
-    async def remove(self, ctx: commands.Context, *games: str):
+    async def remove(self, ctx: commands.Context, *, games: GameList):
         """Remove games from user profile"""
-        games = " ".join(games)
-        games = [game.strip() for game in games.split(",")]
-
         id = str(ctx.author.id)
         with db_session:
             player = Player.get(id=id)
@@ -74,11 +69,8 @@ class UserCog(commands.Cog):
         await ctx.message.add_reaction("👍")
 
     @commands.command()
-    async def ban(self, ctx: commands.Context, *games: str):
+    async def ban(self, ctx: commands.Context, *, games: GameList):
         """Ban games from user profile"""
-        games = " ".join(games)
-        games = [game.strip() for game in games.split(",")]
-
         id = str(ctx.author.id)
         with db_session:
             player = Player.get(id=id)
@@ -89,11 +81,8 @@ class UserCog(commands.Cog):
         await ctx.message.add_reaction("👍")
 
     @commands.command()
-    async def unban(self, ctx: commands.Context, *games: str):
+    async def unban(self, ctx: commands.Context, *, games: GameList):
         """Unban games from user profile"""
-        games = " ".join(games)
-        games = [game.strip() for game in games.split(",")]
-
         id = str(ctx.author.id)
         with db_session:
             player = Player.get(id=id)

--- a/src/main.py
+++ b/src/main.py
@@ -5,7 +5,7 @@ import sys
 import logging
 from datetime import date
 from dotenv import load_dotenv
-from orm import init_database
+from orm import SteamMetaData, init_database, db_session
 from cog import UserCog, ServerCog
 from steamapi import SteamAPI
 import asyncio
@@ -26,10 +26,8 @@ class Filter(object):
 class WhatShouldWePlayBot(commands.Bot):
     # These are the member id's for the bots, we ignore them for specific checks
     _MEMBER_IGNORE_LIST = [959263650701508638, 961433803484712960]
-    _ignore_disallowlist = False
     _ignore_banlist = False
-    _member_count = -1
-    api = SteamAPI(os.getenv("API_KEY"))
+    api: SteamAPI = SteamAPI(os.getenv("API_KEY"))
 
     def __init__(self, db_path: str = ":memory:"):
         intents = discord.Intents.default()
@@ -47,7 +45,12 @@ class WhatShouldWePlayBot(commands.Bot):
             handlers=[stream_handler, file_handler],
         )
 
-        init_database(db_path, self.api.get_app_list())
+        init_database(db_path)
+
+    def sync_with_steam(self):
+        games = self.api.get_app_list()
+        with db_session:
+            SteamMetaData.add_games(games)
 
     async def on_ready(self):
         logging.info(f"Logged in as user {self.user.name}")
@@ -56,11 +59,14 @@ class WhatShouldWePlayBot(commands.Bot):
         # For now, lets just dump the exception we get to the console
         traceback.print_exception(type(error), error, error.__traceback__, file=sys.stderr)
 
+
 async def main():
     bot = WhatShouldWePlayBot(os.getenv("DB_PATH"))
     await bot.add_cog(UserCog(bot))
     await bot.add_cog(ServerCog(bot))
+    await bot.sync_with_steam()
     await bot.start(os.getenv("TOKEN"))
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/src/main.py
+++ b/src/main.py
@@ -30,9 +30,6 @@ class WhatShouldWePlayBot(commands.Bot):
     api: SteamAPI = SteamAPI(os.getenv("API_KEY"))
 
     def __init__(self, db_path: str = ":memory:"):
-        intents = discord.Intents.default()
-        intents.presences = True
-        intents.message_content = True
         super().__init__(command_prefix="$", intents=discord.Intents.all())
         stream_handler = logging.StreamHandler(sys.stdout)
         stream_handler.setLevel(logging.INFO)

--- a/src/main.py
+++ b/src/main.py
@@ -1,13 +1,16 @@
 import discord
+from discord.ext import commands
 import os
 import sys
 import logging
-import random
 from datetime import date
 from dotenv import load_dotenv
-from orm import Player, Game, SteamMetaData, init_database
-from pony.orm import db_session
+from orm import init_database
+from cog import UserCog, ServerCog
 from steamapi import SteamAPI
+import asyncio
+import traceback
+
 
 load_dotenv()
 
@@ -20,15 +23,19 @@ class Filter(object):
         return logRecord.levelno <= self.__level
 
 
-class WhatShouldWePlayBot(discord.Client):
+class WhatShouldWePlayBot(commands.Bot):
     # These are the member id's for the bots, we ignore them for specific checks
     _MEMBER_IGNORE_LIST = [959263650701508638, 961433803484712960]
     _ignore_disallowlist = False
+    _ignore_banlist = False
     _member_count = -1
     api = SteamAPI(os.getenv("API_KEY"))
 
     def __init__(self, db_path: str = ":memory:"):
-        super().__init__(intents=discord.Intents.all())
+        intents = discord.Intents.default()
+        intents.presences = True
+        intents.message_content = True
+        super().__init__(command_prefix="$", intents=discord.Intents.all())
         stream_handler = logging.StreamHandler(sys.stdout)
         stream_handler.setLevel(logging.INFO)
         stream_handler.addFilter(Filter(logging.INFO))
@@ -45,232 +52,15 @@ class WhatShouldWePlayBot(discord.Client):
     async def on_ready(self):
         logging.info(f"Logged in as user {self.user.name}")
 
-    async def on_message(self, message):
-        if message.author == self.user:
-            return
+    async def on_command_error(self, ctx: commands.Context, error: commands.CommandInvokeError):
+        # For now, lets just dump the exception we get to the console
+        traceback.print_exception(type(error), error, error.__traceback__, file=sys.stderr)
 
-        tempCmd = message.content.split(" ", 1)
-        if len(tempCmd) != 1:
-            cmd, msg = tempCmd
-        else:
-            cmd = tempCmd[0]
-            msg = "NONE"
-        cmd = cmd.lower()
-
-        logging.info(f"Message Received from {message.author}: {cmd} {msg}")
-
-        author = message.author
-        id = str(author.id)
-
-        match cmd:
-            case "$add":
-                if msg == "NONE":
-                    await message.channel.send(
-                        "No game provided. Please add games using '$add Game1, Game2'"
-                    )
-                games = [game.strip() for game in msg.split(",")]
-
-                with db_session:
-                    user = Player.get(id=id) or Player(id=id, name=author.name)
-                    user.add_games(*games)
-
-                await message.channel.send(
-                    f'{", ".join(games)} added to {author}\'s record'
-                )
-            case "$remove":
-                games = [game.strip() for game in msg.split(",")]
-
-                with db_session:
-                    user = Player.get(id=id) or Player(id=id, name=author.name)
-                    user.remove_games(*games)
-
-                await message.channel.send(
-                    f'{", ".join(games)} removed from {author}\'s record'
-                )
-            case "$list":
-                out_msg = ""
-                if msg == "NONE":
-                    msg = "games bans"
-                with db_session:
-                    user = Player.get(id=id) or Player(id=id, name=author.name)
-                    names = [game.name for game in user.get_games()]
-                    bans = [game.name for game in user.get_banned_games()]
-                if "games" in msg:
-                    out_msg += f"Games: {', '.join(names)}\n"
-                if "bans" in msg:
-                    out_msg += f"Banned Games: {', '.join(bans)}"
-                await message.channel.send(out_msg)
-            case "$ban":
-                games = [game.strip() for game in msg.split(",")]
-
-                with db_session:
-                    user = Player.get(id=id) or Player(id=id, name=author.name)
-                    user.add_banned_games(*games)
-
-                await message.channel.send(
-                    f'{", ".join(games)} added to {author}\'s disallowlist'
-                )
-            case "$unban":
-                games = [game.strip() for game in msg.split(",")]
-
-                with db_session:
-                    user = Player.get(id=id) or Player(id=id, name=author.name)
-                    user.remove_banned_games(*games)
-
-                await message.channel.send(
-                    f'{", ".join(games)} removed from {author}\'s disallowlist'
-                )
-            case "$suggest":
-                self._member_count = len(message.guild.members)
-                all_games = self.get_games_guild(message.guild)
-                if msg == "*":
-                    out_msg = self.suggest_game(
-                        message.guild, all_games, self._member_count
-                    )
-                elif msg.isdigit():
-                    out_msg = self.suggest_game(message.guild, all_games, int(msg))
-                else:
-                    out_msg = "Selected channel is not a voice channel or spelled incorrectly. Try again."
-                    for channel in message.guild.channels:
-                        if (
-                            msg == channel.name
-                            and channel.type == discord.ChannelType.voice
-                        ):
-                            out_msg = self.suggest_game_for_channel(channel, all_games)
-                if out_msg == []:
-                    out_msg = "No compatible games in library. Choose a different number of players, use '$suggest *', or set '$disallow false'."
-                await message.channel.send(out_msg)
-            case "$disallow":
-                if msg == "true":
-                    self._ignore_disallowlist = False
-                    await message.channel.send("Use disallowlists set to True.")
-                elif msg == "false":
-                    self._ignore_disallowlist = True
-                    await message.channel.send("Use disallowlists set to False.")
-            case "$set":
-                params = [input.strip() for input in msg.split(",")]
-                if len(params) == 2:
-                    game = params[0]
-                    count = params[1]
-
-                    with db_session:
-                        game = Game.get(name=game) or Game(name=game)
-                        game.set_player_count(int(count))
-
-                    out_msg = f'"Set max player count of {game.name} to {count}"'
-                else:
-                    out_msg = "Incorrect command set player count using '$set <game> <max_player_count>'"
-                await message.channel.send(out_msg)
-            case "$link":
-                steamid = msg.strip()
-                games_data = self.api.get_games(steamid)
-                if not games_data:
-                    await message.channel.send("Invalid Steam ID or private profile.")
-                    return
-                appids = []
-                with db_session:
-                    for game_data in games_data:
-                        steam_metadata = SteamMetaData.get(appid=game_data["appid"])
-                        if not steam_metadata:
-                            game_info = self.api.get_games_by_id(game_data["appid"])
-                            if not game_info:
-                                continue
-                            name = game_info["name"]
-                            if not name:
-                                continue
-                            SteamMetaData(
-                                appid=game_data["appid"],
-                                name=name,
-                                game=Game(name=name),
-                            )
-                        appids.append(game_data["appid"])
-
-                with db_session:
-                    user = Player.get(id=id) or Player(id=id, name=author.name)
-                    user.add_games_with_appid(*appids)
-
-                await message.channel.send(f"{len(appids)} added to {author}'s record")
-        return
-
-    async def on_presence_update(self, prev, cur):
-        if prev.activities == cur.activities:
-            return
-
-        if not hasattr(cur.activity, "type"):
-            return
-
-        with db_session:
-            user = Player.get(id=str(cur.id)) or Player(id=str(cur.id), name=cur.name)
-            if cur.activity.type is discord.ActivityType.playing:
-                user.add_games(cur.activity.name)
-                logging.info(
-                    f"User starting playing {cur.activity.name}. Added to user gamelist"
-                )
-
-    @db_session
-    def get_player_count(self, games):
-        data = {}
-        for game in games:
-            game = Game.get(name=game) or Game(name=game)
-            data[game.name] = game.player_count or self._member_count
-        return data
-
-    @db_session
-    def get_games_guild(self, guild):
-        game_data = []
-        for member in guild.members:
-            if (
-                member.id not in self._MEMBER_IGNORE_LIST
-                and member.status == discord.Status.online
-            ):
-                player = Player.get(id=str(member.id)) or Player(
-                    id=str(member.id), name=member.name
-                )
-                game_data.append([game.name for game in player.get_games()])
-        return game_data
-
-    @db_session
-    def get_guild_ban_list(self, guild):
-        disallowlist = []
-        for member in guild.members:
-            if (
-                member.id not in self._MEMBER_IGNORE_LIST
-                and member.status == discord.Status.online
-            ):
-                player = Player.get(id=str(member.id)) or Player(
-                    id=str(member.id), name=member.name
-                )
-                disallowlist += [game.name for game in player.get_banned_games()]
-        return disallowlist
-
-    def suggest_game_for_channel(self, channel, player_data):
-        game = self.suggest_game(channel.guild, player_data, len(channel.members))
-        return game
-
-    def suggest_game(self, guild, game_data, player_count):
-        potential_games = []
-        for gamelist in game_data:
-            potential_games.append(set(gamelist))
-
-        potential_games = set.intersection(*potential_games)
-        player_counts = self.get_player_count(potential_games)
-        disallowlist = self.get_guild_ban_list(guild)
-        games = []
-        for game in potential_games:
-            count_ok = player_count == "*" or player_counts[game] >= int(player_count)
-            disallowlist_ok = game not in disallowlist or self._ignore_disallowlist
-            if count_ok and disallowlist_ok:
-                games.append(game)
-
-        # This is checking to see if there are any games in the list because
-        # random.choice breaks if you give it an empty list.
-        # Note: this is the correct way to check for an empty list apparently.
-        if not games:
-            return games
-        else:
-            return random.choice(games)
-
+async def main():
+    bot = WhatShouldWePlayBot(os.getenv("DB_PATH"))
+    await bot.add_cog(UserCog(bot))
+    await bot.add_cog(ServerCog(bot))
+    await bot.start(os.getenv("TOKEN"))
 
 if __name__ == "__main__":
-    client = WhatShouldWePlayBot(os.getenv("DB_PATH"))
-    client.run(os.getenv("TOKEN"))
+    asyncio.run(main())

--- a/src/main.py
+++ b/src/main.py
@@ -61,7 +61,7 @@ async def main():
     bot = WhatShouldWePlayBot(os.getenv("DB_PATH"))
     await bot.add_cog(UserCog(bot))
     await bot.add_cog(ServerCog(bot))
-    await bot.sync_with_steam()
+    bot.sync_with_steam()
     await bot.start(os.getenv("TOKEN"))
 
 

--- a/src/orm.py
+++ b/src/orm.py
@@ -45,9 +45,7 @@ class Player(db.Entity):
             try:
                 steam_metadata = SteamMetaData.get(name=name)
             except MultipleObjectsFoundError:
-                steam_metadata = (
-                    None  # Set to none for now, because we don't have appid
-                )
+                steam_metadata = None  # Set to none for now, because we don't have appid
             game = Game.get(name=name) or Game(name=name, steam_metadata=steam_metadata)
             self.games += game
 
@@ -116,14 +114,10 @@ class SteamMetaData(db.Entity):
         return
 
 
-def init_database(db_path: str = ":memory:", applist: str = None):
+def init_database(db_path: str = ":memory:"):
     global _is_initialized
     if _is_initialized:
         return
     _is_initialized = True
     db.bind(provider="sqlite", filename=db_path, create_db=True)
     db.generate_mapping(create_tables=True)
-
-    with db_session:
-        if applist:
-            SteamMetaData.add_games(applist)

--- a/src/steamapi.py
+++ b/src/steamapi.py
@@ -39,9 +39,7 @@ class SteamAPI:
             return json.loads(req.text)["applist"]["apps"]
 
     def get_games_by_id(self, appid):
-        req = requests.get(
-            f"http://store.steampowered.com/api/appdetails?appids={appid}"
-        )
+        req = requests.get(f"http://store.steampowered.com/api/appdetails?appids={appid}")
         if req.status_code != 200:
             return []
         if not json.loads(req.text)[str(appid)]["success"]:

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,6 +1,7 @@
 import pytest_asyncio
 import pytest
-from main import WhatShouldWePlayBot, Player, Game, db_session
+from main import WhatShouldWePlayBot, UserCog, ServerCog
+from orm import Player, Game, db_session
 from discord.ext import test
 import os
 import discord
@@ -8,7 +9,9 @@ import discord
 
 @pytest_asyncio.fixture
 async def bot():
-    bot = WhatShouldWePlayBot()
+    bot = WhatShouldWePlayBot("DB.DB")
+    await bot.add_cog(UserCog(bot))
+    await bot.add_cog(ServerCog(bot))
     await bot._async_setup_hook()
 
     test.configure(bot)
@@ -29,7 +32,7 @@ async def test_add_games(bot):
     member = await test.member_join()
     id = str(member.id)
     # Adding games
-    await test.message("$Add Game1, Game 2", member=member)
+    await test.message("$add Game1, Game 2", member=member)
     with db_session:
         player = Player.get(id=id)
         games = [game.name for game in player.get_games()]
@@ -46,7 +49,7 @@ async def test_add_games(bot):
     await test.message("$suggest *", member=member) is not None
 
     # Checking setting a player works
-    await test.message("$set Game 1, 3", member=member)
+    await test.message("$admin set Game 1 players: 3", member=member)
     with db_session:
         game = Game.get(name="Game 1")
         assert game.get_player_count() == 3
@@ -93,9 +96,7 @@ async def test_from_player(bot):
 
         # Adding games
         player.add_games("Game1", "Game 2")
-        assert sorted([game.name for game in player.get_games()]) == sorted(
-            ["Game 2", "Game1"]
-        )
+        assert sorted([game.name for game in player.get_games()]) == sorted(["Game 2", "Game1"])
 
         # Remove a games and test
         player.remove_games("Game1")
@@ -106,9 +107,7 @@ async def test_from_player(bot):
 
         # Adding games to disallow list
         player.add_banned_games("Game1", "Game 2")
-        assert sorted([game.name for game in player.get_banned_games()]) == sorted(
-            ["Game 2", "Game1"]
-        )
+        assert sorted([game.name for game in player.get_banned_games()]) == sorted(["Game 2", "Game1"])
 
         # Remove a games and test
         player.remove_banned_games("Game1")

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -115,3 +115,25 @@ async def test_from_player(bot):
 
         player.remove_banned_games("Game 2")
         assert [game.name for game in player.get_banned_games()] == []
+
+
+@pytest.mark.asyncio
+async def test_suggest(bot):
+    m1 = await test.member_join()
+    m2 = await test.member_join()
+    m3 = await test.member_join()
+
+    for member in test.get_config().guilds[0].members[2:]:
+        member.status = discord.Status.online
+
+    await test.message("$add Game1, Game2, Game3", member=m1)
+    await test.message("$add Game1, Game2", member=m2)
+    await test.message("$add Game1, Game3", member=m3)
+
+    await test.message("$ban Game2", member=m3)
+
+    await test.message("$admin set Game1 players: 3", member=m1)
+
+    await test.message("$suggest 3", member=m1)
+    resp = test.get_message()
+    assert resp.content == "Game1"

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -9,7 +9,7 @@ import discord
 
 @pytest_asyncio.fixture
 async def bot():
-    bot = WhatShouldWePlayBot("DB.DB")
+    bot = WhatShouldWePlayBot()
     await bot.add_cog(UserCog(bot))
     await bot.add_cog(ServerCog(bot))
     await bot._async_setup_hook()


### PR DESCRIPTION
Updates the bot from a `discord.Client` to a `discord.ext.commands.Bot` which is a bit higher level / abstracted compared to the `discord.Client` and adds the ability to use cogs for better organization.

**Updates commands to be case sensitive - I can change this if need be**

Updates dpytest to my fork which has a commit to fix an issue. `dpytest` appears to not be maintained, but there is no better option for testing, so I got the problem fixed.

Updated a few of the commands:
- `$set Game 1, 3` -> `$admin set Game1 players: 3`
- `$disallow true/false` -> `$admin ignore_bans true/false`

Added a new command:
- `$admin list` which lists all games associated with the server.

Moved the steam sync into a standalone function. Call it when we startup the bot normally, but do not call it when we run tests. We can eventually have an admin command to call it, or have it on some time of chron-job type thing.

closes #38 
